### PR TITLE
Changed celery routing

### DIFF
--- a/squadlavalistener/settings/__init__.py
+++ b/squadlavalistener/settings/__init__.py
@@ -136,7 +136,9 @@ BROKER_URL = 'amqp://guest:guest@localhost:5672//'
 CELERY_RESULT_BACKEND = 'rpc://'
 CELERY_RESULT_PERSISTENT = False
 CELERY_ACCEPT_CONTENT = ['json', 'pickle']
-CELERYBEAT_SCHEDULE_FILENAME = "/tmp/celery-beat"
+CELERYBEAT_SCHEDULE_FILENAME = "/tmp/squadlavalistenr-celery-beat"
+CELERY_QUEUE_NAME = "lava"
+CELERY_ROUTES = {"api.tasks.*": {"queue": CELERY_QUEUE_NAME}}
 
 CELERYD_LOG_FORMAT = '[%(asctime)s] %(levelname)s: %(message)s'
 CELERYD_TASK_LOG_FORMAT = '[%(asctime)s] %(levelname)s %(task_name)s: %(message)s'


### PR DESCRIPTION
The celery worker now listens to own exchange/topic. This should prevent
tasks from different workers to be picked up.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>